### PR TITLE
fix: remove output field resolver methods

### DIFF
--- a/src/generator/type-class.ts
+++ b/src/generator/type-class.ts
@@ -97,7 +97,6 @@ export function generateOutputTypeClassFromType(
     ],
     properties: [
       ...type.fields
-        .filter(field => !field.argsTypeName)
         .map<OptionalKind<PropertyDeclarationStructure>>(field => ({
           name: field.name,
           type: field.fieldTSType,
@@ -116,47 +115,7 @@ export function generateOutputTypeClassFromType(
             },
           ],
         })),
-      ...type.fields
-        .filter(field => field.argsTypeName)
-        .map<OptionalKind<PropertyDeclarationStructure>>(field => ({
-          name: field.name,
-          type: field.fieldTSType,
-          hasExclamationToken: true,
-          hasQuestionToken: false,
-        })),
     ],
-    methods: type.fields
-      .filter(field => field.argsTypeName)
-      .map<OptionalKind<MethodDeclarationStructure>>(field => ({
-        name: `get${pascalCase(field.name)}`,
-        returnType: field.fieldTSType,
-        trailingTrivia: "\r\n",
-        decorators: [
-          {
-            name: "Field",
-            arguments: [
-              `_type => ${field.typeGraphQLType}`,
-              Writers.object({
-                name: `"${field.name}"`,
-                nullable: `${!field.isRequired}`,
-              }),
-            ],
-          },
-        ],
-        parameters: [
-          {
-            name: "root",
-            type: type.typeName,
-            decorators: [{ name: "Root", arguments: [] }],
-          },
-          {
-            name: "args",
-            type: field.argsTypeName,
-            decorators: [{ name: "Args", arguments: [] }],
-          },
-        ],
-        statements: [Writers.returnStatement(`root.${field.name}`)],
-      })),
   });
 }
 


### PR DESCRIPTION
As mentioned in issue https://github.com/EndyKaufman/typegraphql-prisma-nestjs/issues/49 currently `typegraphql-prisma` generates field resolver methods, which are not supported by `@nestjs/graphql`.

I have not found a functionality in `@nestjs/graphql` which is similarly defined and which could be used in place.

So far I have only encountered `_count` relations getting field resolver methods generated for them. When `@nestjs/graphql` is queried for those fields - it returns `null` and throws an error, as the counted relations are defined as `nullable: false`.

On the other hand, `@nestjs/graphql` works fine when `_count` does not get any field resolver methods and all the fields are resolved as numbers, which can also be seen in the issue https://github.com/EndyKaufman/typegraphql-prisma-nestjs/issues/49.

Based on all the above, I propose that the issue can be fixed by removing the code that generates field resolver methods, since those are not supported by `@nestjs/graphql` anyway.

The closest functionality to field resolver methods in `@nestjs/graphql` is probably [Field middleware](https://docs.nestjs.com/graphql/field-middleware), but seems to be an overkill.


